### PR TITLE
Add bucket region configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ var protectedProxy = s3BasicAuth({
   key: 'AKIAIOSFODNN7EXAMPLE',
   secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
   host: 'examplebucket.s3.amazonaws.com',
+  region: 'us-west-2', // if not specified, defaults to us-east-1
   expires: 10, // seconds that the presigned URL is valid for
   credentials: 'foo:bar', // username:password
   method: 'proxy' // 'proxy', 'redirect', 'presignedUrl' are valid options
@@ -67,6 +68,7 @@ var s3BasicAuth = require('s3-basic-auth');
 var protectedRedirect = s3BasicAuth({
   key: 'AKIAIOSFODNN7EXAMPLE',
   secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  region: 'us-west-2',
   host: 'examplebucket.s3.amazonaws.com',
   expires: 10,
   credentials: 'foo:bar',
@@ -76,6 +78,7 @@ var protectedRedirect = s3BasicAuth({
 var protectedpresignedUrl = s3BasicAuth({
   key: 'AKIAIOSFODNN7EXAMPLE',
   secret: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+  region: 'us-west-2',
   host: 'examplebucket.s3.amazonaws.com',
   expires: 86400,
   credentials: 'foo:bar',

--- a/lib/generate-presigned-url.js
+++ b/lib/generate-presigned-url.js
@@ -4,13 +4,14 @@ function generatePresignedUrl(path, config) {
   const date = config.s3BasicAuthDateForTestSuite || new Date();
   const iso8601Date = helper.iso8601(date);
   const shortDate = helper.shortDate(date);
+  const region = config.region || 'us-east-1';
 
   // 1. StringToSign
   // ===============
   // a) CanonicalRequest
   const request = new Map([
     ['X-Amz-Algorithm', 'AWS4-HMAC-SHA256'],
-    ['X-Amz-Credential', `${config.key}/${shortDate}/us-east-1/s3/aws4_request`],
+    ['X-Amz-Credential', `${config.key}/${shortDate}/${region}/s3/aws4_request`],
     ['X-Amz-Date', `${iso8601Date}`],
     ['X-Amz-Expires', `${config.expires}`],
     ['X-Amz-SignedHeaders', 'host'],
@@ -27,13 +28,13 @@ UNSIGNED-PAYLOAD`;
   // b) StringToSign
   const stringToSign = `AWS4-HMAC-SHA256
 ${iso8601Date}
-${shortDate}/us-east-1/s3/aws4_request
+${shortDate}/${region}/s3/aws4_request
 ${helper.hash(canonicalRequest)}`;
 
   // 2. Signing key
   // ==============
   const dateKey = helper.hmac(`AWS4${config.secret}`, shortDate);
-  const dateRegionKey = helper.hmac(dateKey, 'us-east-1');
+  const dateRegionKey = helper.hmac(dateKey, region);
   const dateRegionServiceKey = helper.hmac(dateRegionKey, 's3');
   const signingKey = helper.hmac(dateRegionServiceKey, 'aws4_request');
 
@@ -43,7 +44,7 @@ ${helper.hash(canonicalRequest)}`;
 
   // 4. Presigned URL
   // ================
-  return `https://${config.host}/${path}?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=${config.key}%2F${shortDate}%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=${iso8601Date}&X-Amz-Expires=${config.expires}&X-Amz-SignedHeaders=host&X-Amz-Signature=${signature}`;
+  return `https://${config.host}/${path}?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=${config.key}%2F${shortDate}%2F${region}%2Fs3%2Faws4_request&X-Amz-Date=${iso8601Date}&X-Amz-Expires=${config.expires}&X-Amz-SignedHeaders=host&X-Amz-Signature=${signature}`;
 }
 
 module.exports = generatePresignedUrl;


### PR DESCRIPTION
Add a simple config option to specify a bucket region.
If none is provided, the default is us-east-1 (as it was previously hardcoded).